### PR TITLE
src: add job_url param

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ resource_types:
 
 * `repository`: *Required.* BitBucket repository.
 
-* `git`: *Required.* configuration is based on the [Git resource](https://github.com/concourse/git-resource). The branch configuration from the original resource is ignored. 
+* `git`: *Required.* Configuration is based on the [Git resource](https://github.com/concourse/git-resource). The branch configuration from the original resource is ignored.
 
+* `job_url`: *Optional.* Allow users to provide a custom Continuous Integration (CI) job URL. This parameter enables flexibility in reporting build status to an external system. (Concourse variables `$BUILD_TEAM_NAME, $BUILD_PIPELINE_NAME, $BUILD_JOB_NAME, $BUILD_NAME ,$BUILD_ID` are evaluated)
 
 ### Example
 
@@ -108,4 +109,3 @@ Update the build status of pull request with desired state.
 * `name`: *Required.* The name of the build result.
 
 * `description`: *Optional.* Description of the build result.
-

--- a/src/concourse.ts
+++ b/src/concourse.ts
@@ -4,6 +4,7 @@ export interface SourceConfig {
     project: string;
     repository: string;
     limit: number;
+    job_url: string;
     git: {
         uri: string;
         private_key: string;

--- a/src/out.ts
+++ b/src/out.ts
@@ -23,7 +23,17 @@ export class OutCommand {
         const pipeline = process.env.BUILD_PIPELINE_NAME;
         const job = process.env.BUILD_JOB_NAME;
         const build = process.env.BUILD_NAME;
-        const jobUrl = `${baseUrl}/teams/${team}/pipelines/${pipeline}/jobs/${job}/builds/${build}`;
+        const buildID = process.env.BUILD_ID;
+        let jobUrl = source.job_url || `${baseUrl}/teams/${team}/pipelines/${pipeline}/jobs/${job}/builds/${build}`;
+
+        if (source.job_url) {
+          jobUrl = jobUrl.replace(/\$ATC_EXTERNAL_URL/g, baseUrl || '')
+                         .replace(/\$BUILD_TEAM_NAME/g, team || '')
+                         .replace(/\$BUILD_PIPELINE_NAME/g, pipeline || '')
+                         .replace(/\$BUILD_JOB_NAME/g, job || '')
+                         .replace(/\$BUILD_NAME/g, build || '')
+                         .replace(/\$BUILD_ID/g, buildID || '');
+        }
 
         const state: PullRequestState = {
             state: params.state,


### PR DESCRIPTION
Allow users to provide a custom Continuous Integration (CI) job URL. This parameter enables flexibility in reporting build status to an external system. (Concourse variables are evaluated)